### PR TITLE
feat: adds user update and reset API key methods

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -9,8 +9,7 @@ const ProjectUsers = require('./project-users');
 const Projects = require('./projects');
 const TimeEntries = require('./time-entries');
 const Reports = require('./reports');
-const User = require('./user')
-
+const User = require('./user');
 
 /**
  * Main class to interact with the toggl API.

--- a/lib/user.js
+++ b/lib/user.js
@@ -1,5 +1,3 @@
-const { mapData } = require('./utils');
-
 /**
  * Access users. See https://github.com/toggl/toggl_api_docs/blob/master/chapters/users.md
  *
@@ -15,8 +13,8 @@ class User {
    * Gets the current user
    *
    * @param {*} query
-   * @returns The current user. By default the request responds with user properties. From the API documentation, to get all the workspaces, clients, projects, tasks, 
-   * time entries and tags which the user can see, add the parameter with_related_data=true If you want to retrieve objects which have changed after 
+   * @returns The current user. By default the request responds with user properties. From the API documentation, to get all the workspaces, clients, projects, tasks,
+   * time entries and tags which the user can see, add the parameter with_related_data=true If you want to retrieve objects which have changed after
    * certain time, add since parameter to the query. The value should be a unix timestamp (e.g. since=1362579886)
    * @memberof User
    */
@@ -25,7 +23,7 @@ class User {
   }
 
   // /**
-  //  * 
+  //  *
   //  * @param {*} user See https://github.com/toggl/toggl_api_docs/blob/master/chapters/users.md#update-user-data
   //  * @returns The updated user.
   //  * @memberof User
@@ -37,28 +35,26 @@ class User {
     }
 
     // check if the time of day format is valid
-    let validTimeOfDayFormat = ["H:mm","h:mm A"];
+    const validTimeOfDayFormat = ['H:mm', 'h:mm A'];
     if (user.timeofday_format && !validTimeOfDayFormat.find(user.timeofday_format)) {
       throw new Error('timeofday_format must be one of H:mm or h:mm');
     }
 
-    let validDateFormat = ["YYYY-MM-DD", "DD.MM.YYYY", "DD-MM-YYYY", "MM/DD/YYYY", "DD/MM/YYYY", "MM-DD-YYYY"];
+    const validDateFormat = ['YYYY-MM-DD', 'DD.MM.YYYY', 'DD-MM-YYYY', 'MM/DD/YYYY', 'DD/MM/YYYY', 'MM-DD-YYYY'];
     if (user.dateFormat && !validDateFormat.find(user.date_format)) {
-      throw new Error('date_format must be one of "YYYY-MM-DD", "DD.MM.YYYY", "DD-MM-YYYY", "MM/DD/YYYY", "DD/MM/YYYY", "MM-DD-YYYY"')
+      throw new Error('date_format must be one of "YYYY-MM-DD", "DD.MM.YYYY", "DD-MM-YYYY", "MM/DD/YYYY", "DD/MM/YYYY", "MM-DD-YYYY"');
     }
-    return await this.client.put(this.endpoint, {user: user});
+    return await this.client.put(this.endpoint, { user: user });
   }
 
   /**
    * Resets API token https://github.com/toggl/toggl_api_docs/blob/master/chapters/users.md#reset-api-token
    * @returns New API token {String}
-   * @memberof User 
+   * @memberof User
    */
   async resetToken() {
     return await this.client.post('reset_token');
   }
-
-
 }
 
 module.exports = User;

--- a/lib/user.js
+++ b/lib/user.js
@@ -35,14 +35,13 @@ class User {
   //   return await this.client.put(this.endpoint, user);
   // }
 
-  // ! FOR FUTURE USE
   /**
-   * 
+   * Resets API token https://github.com/toggl/toggl_api_docs/blob/master/chapters/users.md#reset-api-token
    * @returns New API token {String}
    * @memberof User 
    */
   async resetToken() {
-    return await this.client.put('reset_token', user);
+    return await this.client.post('reset_token');
   }
 
 

--- a/lib/user.js
+++ b/lib/user.js
@@ -24,16 +24,30 @@ class User {
     return await this.client.get(this.endpoint, query);
   }
 
-  // ! FOR FUTURE USE
   // /**
   //  * 
   //  * @param {*} user See https://github.com/toggl/toggl_api_docs/blob/master/chapters/users.md#update-user-data
   //  * @returns The updated user.
   //  * @memberof User
   //  */
-  // async update(user) {
-  //   return await this.client.put(this.endpoint, user);
-  // }
+  async update(user) {
+    // Check if attempting to change the password
+    if (user.password && !user.current_password) {
+      throw new Error('To change the password you must include the current password');
+    }
+
+    // check if the time of day format is valid
+    let validTimeOfDayFormat = ["H:mm","h:mm A"];
+    if (user.timeofday_format && !validTimeOfDayFormat.find(user.timeofday_format)) {
+      throw new Error('timeofday_format must be one of H:mm or h:mm');
+    }
+
+    let validDateFormat = ["YYYY-MM-DD", "DD.MM.YYYY", "DD-MM-YYYY", "MM/DD/YYYY", "DD/MM/YYYY", "MM-DD-YYYY"];
+    if (user.dateFormat && !validDateFormat.find(user.date_format)) {
+      throw new Error('date_format must be one of "YYYY-MM-DD", "DD.MM.YYYY", "DD-MM-YYYY", "MM/DD/YYYY", "DD/MM/YYYY", "MM-DD-YYYY"')
+    }
+    return await this.client.put(this.endpoint, {user: user});
+  }
 
   /**
    * Resets API token https://github.com/toggl/toggl_api_docs/blob/master/chapters/users.md#reset-api-token

--- a/test/smoke-test.js
+++ b/test/smoke-test.js
@@ -42,44 +42,47 @@ describe('smoke test', () => {
     expect(detailsReport).to.exist.to.be.an('object');
   });
 
-  it('should get a user', async() => {
+  it('should get a user', async () => {
     const client = togglClient();
     const user = await client.user.current();
     debug(user);
     expect(user).to.exist.to.be.an('object');
+  });
 
-  })
-
-  it.skip('should get a new API token',async() =>{
+  it.skip('should get a new API token', async () => {
     const client = togglClient();
     const newToken = await client.user.resetToken();
     debug(newToken);
     expect(newToken).to.exist.to.be.an('string');
-  })
+  });
 
-  it('should throw an error if current password not supplied',async() =>{
+  it('should throw an error if current password not supplied', async () => {
     const client = togglClient();
     const user = {
       password: 'foo',
     };
     expect(() => client.user.update(user).to.throw('To change the password you must include the current password'));
-  })
+  });
 
-  it('should throw an error if time of day format is invalid',async() =>{
+  it('should throw an error if time of day format is invalid', async () => {
     const client = togglClient();
     const user = {
       timeofday_format: 'foo',
     };
     expect(() => client.user.update(user).to.throw(Error('timeofday_format must be one of H:mm or h:mm')));
-  })
+  });
 
-  it('should throw an error if date format is invalid',async() =>{
+  it('should throw an error if date format is invalid', async () => {
     const client = togglClient();
     const user = {
       dateFormat: 'foo',
     };
-    expect(() => client.user.update(user).to.throw(Error('date_format must be one of "YYYY-MM-DD", "DD.MM.YYYY", "DD-MM-YYYY", "MM/DD/YYYY", "DD/MM/YYYY", "MM-DD-YYYY"')));
-  })
+    expect(() =>
+      client.user
+        .update(user)
+        .to.throw(Error('date_format must be one of "YYYY-MM-DD", "DD.MM.YYYY", "DD-MM-YYYY", "MM/DD/YYYY", "DD/MM/YYYY", "MM-DD-YYYY"')),
+    );
+  });
 
   it.skip('should generate time entries', async () => {
     const client = togglClient();

--- a/test/smoke-test.js
+++ b/test/smoke-test.js
@@ -50,6 +50,13 @@ describe('smoke test', () => {
 
   })
 
+  it.skip('should get a new API token',async() =>{
+    const client = togglClient();
+    const newToken = await client.user.resetToken();
+    debug(newToken);
+    expect(newToken).to.exist.to.be.an('string');
+  })
+
   it('should generate time entries', async () => {
     const client = togglClient();
     const workspaces = await client.workspaces.list();

--- a/test/smoke-test.js
+++ b/test/smoke-test.js
@@ -81,6 +81,7 @@ describe('smoke test', () => {
     expect(() => client.user.update(user).to.throw(Error('date_format must be one of "YYYY-MM-DD", "DD.MM.YYYY", "DD-MM-YYYY", "MM/DD/YYYY", "DD/MM/YYYY", "MM-DD-YYYY"')));
   })
 
+  it.skip('should generate time entries', async () => {
     const client = togglClient();
     const workspaces = await client.workspaces.list();
 

--- a/test/smoke-test.js
+++ b/test/smoke-test.js
@@ -57,7 +57,30 @@ describe('smoke test', () => {
     expect(newToken).to.exist.to.be.an('string');
   })
 
-  it('should generate time entries', async () => {
+  it('should throw an error if current password not supplied',async() =>{
+    const client = togglClient();
+    const user = {
+      password: 'foo',
+    };
+    expect(() => client.user.update(user).to.throw('To change the password you must include the current password'));
+  })
+
+  it('should throw an error if time of day format is invalid',async() =>{
+    const client = togglClient();
+    const user = {
+      timeofday_format: 'foo',
+    };
+    expect(() => client.user.update(user).to.throw(Error('timeofday_format must be one of H:mm or h:mm')));
+  })
+
+  it('should throw an error if date format is invalid',async() =>{
+    const client = togglClient();
+    const user = {
+      dateFormat: 'foo',
+    };
+    expect(() => client.user.update(user).to.throw(Error('date_format must be one of "YYYY-MM-DD", "DD.MM.YYYY", "DD-MM-YYYY", "MM/DD/YYYY", "DD/MM/YYYY", "MM-DD-YYYY"')));
+  })
+
     const client = togglClient();
     const workspaces = await client.workspaces.list();
 


### PR DESCRIPTION
new User methods

* `resetToken` will get new API token. Unit test is skipped because its disruptive
* `update` will update user. Throws error if data doesn't match required formats. Has unit tests - but I'm not very good at them.

Also

* skips the generate time entry test because its disruptive to the data
* fixes linting issues
