### PR TITLE
Disables got retry logic

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -75,7 +75,7 @@ class TogglClient {
 
   async request(path, options) {
     // Disables retry logic following suggestion from https://github.com/sindresorhus/got/issues/1489
-    options.retry = {limit:0};
+    options.retry = { limit: 0 };
     debug('requesting toggl API path %s with options %o', path, options);
 
     const response = await this.httpClient(path, options);

--- a/lib/client.js
+++ b/lib/client.js
@@ -74,6 +74,8 @@ class TogglClient {
   }
 
   async request(path, options) {
+    // Disables retry logic following suggestion from https://github.com/sindresorhus/got/issues/1489
+    options.retry = {limit:0};
     debug('requesting toggl API path %s with options %o', path, options);
 
     const response = await this.httpClient(path, options);


### PR DESCRIPTION
Disables retry logic following suggestion from https://github.com/sindresorhus/got/issues/1489 to prevent ` throw new Error('The `onCancel` handler was attached after the promise settled.')`

I've not updated my client to ESM so I'm unable to test this on the latest version, but I've been running this based upon your commit prior to the ESM conversion, 250191a4900912a193dd3b3a24c1f343188bdcfd 


This is to prevent this error from occurring

```
/Users/beauraines/projects/toggl-cli-node/node_modules/p-cancelable/index.js:48
                    throw new Error('The `onCancel` handler was attached after the promise settled.');
                          ^

Error: The `onCancel` handler was attached after the promise settled.
    at onCancel (/Users/beauraines/projects/toggl-cli-node/node_modules/p-cancelable/index.js:48:12)
    at makeRequest (/Users/beauraines/projects/toggl-cli-node/node_modules/got/dist/source/as-promise/index.js:38:13)
    at Request.<anonymous> (/Users/beauraines/projects/toggl-cli-node/node_modules/got/dist/source/as-promise/index.js:143:17)
    at Object.onceWrapper (node:events:628:26)
    at Request.emit (node:events:513:28)
    at Timeout.retry (/Users/beauraines/projects/toggl-cli-node/node_modules/got/dist/source/core/index.js:1278:30)
    at listOnTimeout (node:internal/timers:559:17)
    at processTimers (node:internal/timers:502:7)
```