### PR TITLE
chore: allows CI job to see secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  pull_request_target:
+    branches: [ master ]
+
 
 jobs:
   build:


### PR DESCRIPTION
Adds new trigger `pull_request_target` to the CI job because allows the run to see the secrets.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull-request-events-for-forked-repositories-2

It seems that the `pull_request` trigger doesn't make the secrets available for PRs from forked repositoriies, but this one should. So this should make my PRs actually execute the unit tests.