### PR TITLE
fix: issues with update time entry method

### DIFF
--- a/lib/time-entries.js
+++ b/lib/time-entries.js
@@ -64,7 +64,7 @@ class TimeEntries {
   }
 
   async update(id, time_entry) {
-    return mapData(await this.client.put(`workspaces/${time_entry.workspace_id}/time_entries/${id}`, { time_entry }));
+    return await this.client.put(`workspaces/${time_entry.workspace_id}/time_entries/${id}`, time_entry);
   }
 
   async delete(id) {


### PR DESCRIPTION
1. the time entry `update()` was passing data through the `mapData()` function
2. the time entry payload was being wrapped in an object rather than being sent as is.