### PR TITLE
fix: Weekly report end points are using the wrong start date

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
       - name: git setup

--- a/lib/reports.js
+++ b/lib/reports.js
@@ -15,7 +15,7 @@ class Reports {
    * https://developers.track.toggl.com/docs/reports/weekly_reports#post-search-time-entries
    */
   async weekly(workspaceId, params) {
-    params = { ...params, start_date: dayjs().subtract(1, 'week').startOf('day').format('YYYY-MM-DD') };
+    params = { ...params, start_date: dayjs().startOf('week').format('YYYY-MM-DD') };
     return await this.requestReport(`workspace/${workspaceId}/weekly/time_entries`, workspaceId, params);
   }
 
@@ -24,7 +24,7 @@ class Reports {
    * https://developers.track.toggl.com/docs/reports/weekly_reports#post-search-time-entries
    */
   async weeklyAll(workspaceId, params) {
-    params = { ...params, start_date: dayjs().subtract(1, 'week').startOf('day').format('YYYY-MM-DD') };
+    params = { ...params, start_date: dayjs().startOf('week').format('YYYY-MM-DD') };
     return await this.requestReport(`workspace/${workspaceId}/weekly/time_entries`, workspaceId, params);
   }
 

--- a/lib/reports.js
+++ b/lib/reports.js
@@ -15,7 +15,7 @@ class Reports {
    * https://developers.track.toggl.com/docs/reports/weekly_reports#post-search-time-entries
    */
   async weekly(workspaceId, params) {
-    params = { start_date: dayjs().startOf('week').format('YYYY-MM-DD'),...params };
+    params = { start_date: dayjs().startOf('week').format('YYYY-MM-DD'), ...params };
     return await this.requestReport(`workspace/${workspaceId}/weekly/time_entries`, workspaceId, params);
   }
 
@@ -24,7 +24,7 @@ class Reports {
    * https://developers.track.toggl.com/docs/reports/weekly_reports#post-search-time-entries
    */
   async weeklyAll(workspaceId, params) {
-    params = { start_date: dayjs().startOf('week').format('YYYY-MM-DD'),...params };
+    params = { start_date: dayjs().startOf('week').format('YYYY-MM-DD'), ...params };
     return await this.requestReport(`workspace/${workspaceId}/weekly/time_entries`, workspaceId, params);
   }
 

--- a/lib/reports.js
+++ b/lib/reports.js
@@ -15,7 +15,7 @@ class Reports {
    * https://developers.track.toggl.com/docs/reports/weekly_reports#post-search-time-entries
    */
   async weekly(workspaceId, params) {
-    params = { ...params, start_date: dayjs().startOf('week').format('YYYY-MM-DD') };
+    params = { start_date: dayjs().startOf('week').format('YYYY-MM-DD'),...params };
     return await this.requestReport(`workspace/${workspaceId}/weekly/time_entries`, workspaceId, params);
   }
 
@@ -24,7 +24,7 @@ class Reports {
    * https://developers.track.toggl.com/docs/reports/weekly_reports#post-search-time-entries
    */
   async weeklyAll(workspaceId, params) {
-    params = { ...params, start_date: dayjs().startOf('week').format('YYYY-MM-DD') };
+    params = { start_date: dayjs().startOf('week').format('YYYY-MM-DD'),...params };
     return await this.requestReport(`workspace/${workspaceId}/weekly/time_entries`, workspaceId, params);
   }
 


### PR DESCRIPTION
Fixes an issue where the weekly report was starting from 7 days ago rather than the beginning of the week

Also, updates github actions to use v3 checkout