### PR TITLE
Updates the trigger for the CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: Node.js CI
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
   pull_request_target:
     branches: [ master ]
 


### PR DESCRIPTION
Removes the `pull_request` trigger and only does it on `pull_request_target` This should reduce the number of unit CI tests that attempt to run and allow the PRs to be merged.