### PR TITLE
Revert workflow change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: Node.js CI
 on:
   push:
     branches: [ master ]
+  pull_request:
+    branches: [ master ]
   pull_request_target:
     branches: [ master ]
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
       - name: git setup


### PR DESCRIPTION
I'm beginning to think that the change to the CI trigger in #49  is causing the problem.

We're seeing that in almost all cases, the CI job is running against `master` not the latest commit from the branch. 

You can see this in that **only one** of the recent workflow runs, it is reporting a branch name.  This is the only test run that successfully `cat` the time entries file. 

After some more reading, I'm not sure that PRs from _forked_ repositories are allowed to access the secret toggl API token even with `pull_request_target`.  See the announcement when the feature was launched. https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks

So, I'm going to put back **BOTH** events and we should expect that they'll pass the linting because they pull in the latest code but then the tests should fail.

I think in the long run, I need to do development not from my fork, but directly from this repo now that I'm a collaborator.

I need to step away for a few hours so I'm going to let this sit. It will also let me think on it for a while too.