### PR TITLE
Revert "Updates the trigger for the CI job"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: Node.js CI
 on:
   push:
     branches: [ master ]
+  pull_request:
+    branches: [ master ]
   pull_request_target:
     branches: [ master ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-  pull_request_target:
-    branches: [ master ]
 
 
 jobs:

--- a/lib/time-entries.js
+++ b/lib/time-entries.js
@@ -73,4 +73,3 @@ class TimeEntries {
 }
 
 export default TimeEntries;
-


### PR DESCRIPTION
Reverts saintedlama/toggl-client#49

I'm beginning to think that the change to the CI trigger in #49  is causing the problem.

We're seeing that in almost all cases, the CI job is running against `master` not the latest commit from the branch. 

You can see this in that **only one** of the recent workflow runs, it is reporting a branch name.  This is the only test run that successfully `cat` the time entries file. 

After some more reading, I'm not sure that PRs from _forked_ repositories are allowed to access the secret toggl API token even with `pull_request_target`.  See the announcement when the feature was launched. https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks

So, I'm going to put back **BOTH** events and we should expect that they'll pass the linting because they pull in the latest code but then the tests should fail.

I think in the long run, I need to do development not from my fork, but directly from this repo now that I'm a collaborator.