### PR TITLE
feat(tags): adds v9 API tag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Summary report containing all pages fetched with wait time between requests of 1
 
 ### Tags
 
-Access Tasgs. See <https://github.com/toggl/toggl_api_docs/blob/master/chapters/tags.md>
+ * Access Tags. See https://developers.track.toggl.com/docs/api/tags
 
 #### create
 
@@ -310,7 +310,8 @@ Creates a new tag
 
 ##### Parameters
 
-*   `tag` **any** 
+*   `workspace_id` **([number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number))** Workspace Id for the tag
+*   `tag` **object** `{name: "tag_name", workspace_id?: number}`
 
 Returns **any** Tag created
 
@@ -320,8 +321,9 @@ Updates an existing tag
 
 ##### Parameters
 
+*   `workspace_id` **([number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number))** Workspace Id for the tag
 *   `id` **([number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number) | [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))** Id of the tag to be updated
-*   `tag` **any** 
+*   `tag` **object** `{name: "tag_name", workspace_id?: number}`
 
 Returns **any** Updated tag
 
@@ -331,6 +333,7 @@ Deletes an existing tag
 
 ##### Parameters
 
+*   `workspace_id` **([number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number))** Workspace Id for the tag
 *   `id` **([number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number) | [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))** If of the tag to be deleted
 
 ### TimeEntries

--- a/README.md
+++ b/README.md
@@ -491,3 +491,4 @@ Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Globa
 *   `rounding` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** type of rounding
 *   `rounding_minutes` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** round up to nearest minute
 *   `at` **[date](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date)** Indicates when the workspace was created or updated
+

--- a/lib/client.js
+++ b/lib/client.js
@@ -90,7 +90,9 @@ class TogglClient {
       throw new Error(`Toggl API responded with status code ${response.statusCode}. Response: ${response.body}`);
     }
 
-    return JSON.parse(response.body);
+    const resp = response.body ? JSON.parse(response.body) : {};
+    debug(resp)
+    return resp;
   }
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -91,7 +91,7 @@ class TogglClient {
     }
 
     const resp = response.body ? JSON.parse(response.body) : {};
-    debug(resp)
+    debug(resp);
     return resp;
   }
 }

--- a/lib/tags.js
+++ b/lib/tags.js
@@ -1,5 +1,3 @@
-import { mapData } from './utils.js';
-
 /**
  * Access Tags. See https://developers.track.toggl.com/docs/api/tags
  *
@@ -33,7 +31,7 @@ class Tags {
   async create(workspace_id, tag) {
     this.validateTag(tag);
     tag = { ...tag, workspace_id };
-    return mapData(await this.client.post(`workspaces/${workspace_id}/tags`, tag));
+    return await this.client.post(`workspaces/${workspace_id}/tags`, tag);
   }
 
   /**

--- a/lib/tags.js
+++ b/lib/tags.js
@@ -1,7 +1,7 @@
 import { mapData } from './utils.js';
 
 /**
- * Access Tasgs. See https://github.com/toggl/toggl_api_docs/blob/master/chapters/tags.md
+ * Access Tags. See https://developers.track.toggl.com/docs/api/tags
  *
  * @class Tags
  */

--- a/lib/tags.js
+++ b/lib/tags.js
@@ -11,36 +11,54 @@ class Tags {
   }
 
   /**
+   * Validates that a tag contains the name property.
+   *
+   * @param {Object} tag The tag object to be validated
+   * @throws {Error} 'The tag must include name'
+   */
+  validateTag(tag) {
+    if (!tag.name) {
+      throw new Error('The tag must include name');
+    }
+  }
+
+  /**
    * Creates a new tag
    *
-   * @param {*} tag
+   * @param {number} workspace_id Id of the workspace
+   * @param {object} tag A tag object with the property `name` and optionally `workspace_id`
    * @returns Tag created
    * @memberof Tags
    */
-  async create(tag) {
-    return mapData(await this.client.post('tags', { tag }));
+  async create(workspace_id, tag) {
+    this.validateTag(tag);
+    tag = { ...tag, workspace_id };
+    return mapData(await this.client.post(`workspaces/${workspace_id}/tags`, tag));
   }
 
   /**
    * Updates an existing tag
    *
+   * @param {number} workspace_id Id of the workspace
    * @param {(number|string)} id Id of the tag to be updated
-   * @param {*} tag
+   * @param {object} tag A tag object with the property `name` and optionally `workspace_id`
    * @returns Updated tag
    * @memberof Tags
    */
-  async update(id, tag) {
-    return mapData(await this.client.put(`tags/${id}`, { tag }));
+  async update(workspace_id, id, tag) {
+    this.validateTag(tag);
+    return await this.client.put(`workspaces/${workspace_id}/tags/${id}`, tag);
   }
 
   /**
    * Deletes an existing tag
    *
+   * @param {number} workspace_id Id of the workspace
    * @param {(number|string)} id If of the tag to be deleted
    * @memberof Tags
    */
-  async delete(id) {
-    await this.client.delete(`tags/${id}`);
+  async delete(workspace_id, id) {
+    await this.client.delete(`workspaces/${workspace_id}/tags/${id}`);
   }
 }
 

--- a/test/tags.test.js
+++ b/test/tags.test.js
@@ -5,54 +5,38 @@ import togglClient from '../index.js';
 
 const debug = debugClient('toggl-client-tests-tags');
 
-// TODO look at beforeAll or beforeEach
-
-describe.skip('tags', async () => {
-  it('should create a tag', async () => {
+describe('tags', async () => {
+  it('should create, update and delete a tag', async () => {
     const tag = { name: `testing-${Date.now()}` };
     debug(tag);
+
     const client = togglClient();
     const workspaces = await client.workspaces.list();
     const workspace_id = workspaces[0].id;
     debug(workspace_id);
+
     const createdTag = await client.tags.create(workspace_id, tag);
+    debug('createdTag');
     debug(createdTag);
     expect(createdTag).to.be.an('object');
     expect(createdTag).to.have.property('name').equal(tag.name);
     expect(createdTag).to.have.property('at');
     expect(createdTag).to.have.property('workspace_id');
     expect(createdTag).to.have.property('id');
-  });
 
-  it('should update a tag', async () => {
-    // FIXME How to make this idempotent and clean up after itself
-    // Check out https://stackoverflow.com/a/21704397
-    const tag = {
-      id: 13932627,
-      workspace_id: 403916,
-    };
-    const client = togglClient();
-    // const workspaces = await client.workspaces.list();
-    // const workspace_id = workspaces[0].id;
-    const workspace_id = tag.workspace_id;
-    debug(workspace_id);
+    const updatedTagName = `${tag.name}-updated`;
 
-    const newName = 'testing-newname2';
-    const updatedTag = await client.tags.update(workspace_id, tag.id, { name: newName });
+    const updatedTag = await client.tags.update(workspace_id, createdTag.id, { name: updatedTagName });
+    debug('updatedTag')
     debug(updatedTag);
     expect(updatedTag).to.be.an('object');
-    expect(updatedTag).to.have.property('name').equal(newName);
+    expect(updatedTag).to.have.property('name').equal(updatedTagName);
     expect(updatedTag).to.have.property('at');
     expect(updatedTag).to.have.property('workspace_id');
     expect(updatedTag).to.have.property('id');
-  });
 
-  it.skip('should delete a tag', async () => {
-    // FIXME How to make this idempotent and clean up after itself
-    const id = 13932627;
-    const workspace_id = 403916;
-    const client = togglClient();
-    // TODO - delete doesn't return any thing. What is there to test?
-    await client.tags.delete(workspace_id, id);
+    await client.tags.delete(workspace_id, updatedTag.id);
+    const tags = await client.workspaces.tags(workspace_id);
+    expect(tags).to.not.include.members([updatedTag]);
   });
 });

--- a/test/tags.test.js
+++ b/test/tags.test.js
@@ -5,7 +5,7 @@ import togglClient from '../index.js';
 
 const debug = debugClient('toggl-client-tests-tags');
 
-describe('tags', async () => {
+describe.skip('tags', async () => {
   it('should create, update and delete a tag', async () => {
     const tag = { name: `testing-${Date.now()}` };
     debug(tag);

--- a/test/tags.test.js
+++ b/test/tags.test.js
@@ -5,7 +5,9 @@ import togglClient from '../index.js';
 
 const debug = debugClient('toggl-client-tests-tags');
 
-describe.only('tags', async () => {
+// TODO look at beforeAll or beforeEach
+
+describe.skip('tags', async () => {
   it('should create a tag', async () => {
     const tag = { name: `testing-${Date.now()}` };
     debug(tag);
@@ -22,29 +24,34 @@ describe.only('tags', async () => {
     expect(createdTag).to.have.property('id');
   });
 
-  it('should update a tag',()=>{
-    const tag = {
-      "id": 13932456,
-      "workspace_id": 403916,
-      "name": "testing2",
-      "at": "2023-03-12T22:40:33.237553Z"
+  it('should update a tag', async () => {
+    // FIXME How to make this idempotent and clean up after itself
+    // Check out https://stackoverflow.com/a/21704397
+      id: 13932627,
+      workspace_id: 403916,
     };
-    debug(tag);
     const client = togglClient();
     // const workspaces = await client.workspaces.list();
     // const workspace_id = workspaces[0].id;
     const workspace_id = tag.workspace_id;
     debug(workspace_id);
 
-    const newName = 'testing-newname'
-    const updatedTag = await client.tags.update(workspace_id, {name:newName});
+    const newName = 'testing-newname2';
+    const updatedTag = await client.tags.update(workspace_id, tag.id, { name: newName });
     debug(updatedTag);
     expect(updatedTag).to.be.an('object');
-    expect(updatedTag).to.have.property('name').equal(tag.newName);
+    expect(updatedTag).to.have.property('name').equal(newName);
     expect(updatedTag).to.have.property('at');
     expect(updatedTag).to.have.property('workspace_id');
     expect(updatedTag).to.have.property('id');
   });
 
-  it('should delete a tag');
+  it.skip('should delete a tag', async () => {
+    // FIXME How to make this idempotent and clean up after itself
+    const id = 13932627;
+    const workspace_id = 403916;
+    const client = togglClient();
+    // TODO - delete doesn't return any thing. What is there to test?
+    await client.tags.delete(workspace_id, id);
+  });
 });

--- a/test/tags.test.js
+++ b/test/tags.test.js
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import dayjs from 'dayjs';
 import debugClient from 'debug';
 import togglClient from '../index.js';
 
@@ -27,7 +26,7 @@ describe.skip('tags', async () => {
     const updatedTagName = `${tag.name}-updated`;
 
     const updatedTag = await client.tags.update(workspace_id, createdTag.id, { name: updatedTagName });
-    debug('updatedTag')
+    debug('updatedTag');
     debug(updatedTag);
     expect(updatedTag).to.be.an('object');
     expect(updatedTag).to.have.property('name').equal(updatedTagName);

--- a/test/tags.test.js
+++ b/test/tags.test.js
@@ -6,10 +6,9 @@ import togglClient from '../index.js';
 const debug = debugClient('toggl-client-tests-tags');
 
 describe.only('tags', async () => {
-  const tag = { name: `testing-${Date.now()}` };
-  debug(tag);
-
   it('should create a tag', async () => {
+    const tag = { name: `testing-${Date.now()}` };
+    debug(tag);
     const client = togglClient();
     const workspaces = await client.workspaces.list();
     const workspace_id = workspaces[0].id;
@@ -23,7 +22,29 @@ describe.only('tags', async () => {
     expect(createdTag).to.have.property('id');
   });
 
-  it('should update a tag');
+  it('should update a tag',()=>{
+    const tag = {
+      "id": 13932456,
+      "workspace_id": 403916,
+      "name": "testing2",
+      "at": "2023-03-12T22:40:33.237553Z"
+    };
+    debug(tag);
+    const client = togglClient();
+    // const workspaces = await client.workspaces.list();
+    // const workspace_id = workspaces[0].id;
+    const workspace_id = tag.workspace_id;
+    debug(workspace_id);
+
+    const newName = 'testing-newname'
+    const updatedTag = await client.tags.update(workspace_id, {name:newName});
+    debug(updatedTag);
+    expect(updatedTag).to.be.an('object');
+    expect(updatedTag).to.have.property('name').equal(tag.newName);
+    expect(updatedTag).to.have.property('at');
+    expect(updatedTag).to.have.property('workspace_id');
+    expect(updatedTag).to.have.property('id');
+  });
 
   it('should delete a tag');
 });

--- a/test/tags.test.js
+++ b/test/tags.test.js
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+import dayjs from 'dayjs';
+import debugClient from 'debug';
+import togglClient from '../index.js';
+
+const debug = debugClient('toggl-client-tests-tags');
+
+describe.only('tags', async () => {
+  const tag = { name: `testing-${Date.now()}` };
+  debug(tag);
+
+  it('should create a tag', async () => {
+    const client = togglClient();
+    const workspaces = await client.workspaces.list();
+    const workspace_id = workspaces[0].id;
+    debug(workspace_id);
+    const createdTag = await client.tags.create(workspace_id, tag);
+    debug(createdTag);
+    expect(createdTag).to.be.an('object');
+    expect(createdTag).to.have.property('name').equal(tag.name);
+    expect(createdTag).to.have.property('at');
+    expect(createdTag).to.have.property('workspace_id');
+    expect(createdTag).to.have.property('id');
+  });
+
+  it('should update a tag');
+
+  it('should delete a tag');
+});


### PR DESCRIPTION
Adds v9 support for tags, which now requires the `workspace_id` to be included in the method call.
Adds unit test (currently skipped) for tags, which will create, update and delete a tag, all in one pass. This will at least clean up after itself, but if it fails along the way it leaves some garbage behind.
Adds support for empty API responses, because the delete endpoints return an empty response

Closes #37
