### PR TITLE
feat: all time-entries functions suppport v9

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Gets an existing project by id
 
 *   `id` **([number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number) | [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))** Id of the project to get
 
-Returns **any** Project if a project with the specified id exists, othererwise undefined
+Returns **any** Project if a project with the specified id exists, otherwise undefined
 
 #### update
 
@@ -338,27 +338,65 @@ Deletes an existing tag
 
 ### TimeEntries
 
-Access time entries. See <https://github.com/toggl/toggl_api_docs/blob/master/chapters/time_entries.md>
+Access time entries. See https://developers.track.toggl.com/docs/api/time_entries
 
 #### list
 
-Lists time entries
+Lists time entries. The `query` must include `start_date` and `end_date`. Note that due to limitations of the v9 API, start_date must not be earlier 3 months ago. If you want results further back, use the reports endpoints.
 
 ##### Parameters
 
-*   `query` **any** 
+*   `query` **any** must include `start_date` and `end_date` and must be within the last 30 days.
 
 Returns **any** List of time entries
 
-#### create
+#### create or start
 
 Creates a new time entry
 
 ##### Parameters
 
-*   `time_entry` **any** 
+*   `time_entry` **any** must include `workspace_id` and `start`
 
 Returns **any** 
+
+#### stop
+
+Stops the current running time entry
+#### Parameters
+
+*   `time_entry` **any** time entry to stop, must include `workspace_id` and `id`
+
+
+#### current
+
+Gets the current running time entry
+
+Returns **any|null** Time Entry
+
+
+#### get
+
+Gets the time entry specified by id. Due to limitations of the v9 API, start_date must not be earlier than 3 months ago. If you want results further back, use the reports endpoints.
+
+#### Parameters
+
+*   `id` **[(number)](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** id of the time entry to be returned
+
+Returns **any|null** Time Entry
+
+
+#### update
+
+Updates an existing time entry
+
+#### Parameters
+
+*   `id` **[(number)](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** id of the time entry to be updated
+*   `time_entry` **any** time entry with updated information
+
+Returns **any** List of time entries
+
 
 ### User
 

--- a/lib/time-entries.js
+++ b/lib/time-entries.js
@@ -67,20 +67,28 @@ class TimeEntries {
     });
   }
 
-    /**
-   * Stops the current running time entry
-   * @returns
-   * @memberof TimeEntries
-   */
+  /**
+ * Stops the current running time entry
+ * @returns
+ * @memberof TimeEntries
+ */
   async stop(time_entry) {
     const workspace_id = time_entry.workspace_id;
     const time_entry_id = time_entry.id;
     return await this.client.patch(`workspaces/${workspace_id}/time_entries/${time_entry_id}/stop`);
   }
 
+  /**
+   * Gets the time entry specified by idt
+   *
+   * @param {*} id
+   * @returns TimeEntry
+   */
   async get(id) {
-    // TODO looks like this endpoint doesn't have a v9 match, at least in the documentation
-    return mapData(await this.client.get(`time_entries/${id}`));
+    // FIXME make these dates dynamic
+    const timeEntries = await this.client.get('me/time_entries', { start_date: '2023-01-01', end_date: '2023-04-02' });
+    const timeEntry = timeEntries.filter((x) => x.id == id)[0];
+    return timeEntry
   }
 
   /**

--- a/lib/time-entries.js
+++ b/lib/time-entries.js
@@ -35,12 +35,6 @@ class TimeEntries {
    * @memberof TimeEntries
    */
   async create(time_entry) {
-    if (!time_entry || !Object.prototype.hasOwnProperty.call(time_entry, 'workspace_id')) {
-      throw new Error('The parameters must include workspace_id');
-    }
-    if (!time_entry || !Object.prototype.hasOwnProperty.call(time_entry, 'start')) {
-      throw new Error('The parameters must include start');
-    }
     return await this.client.post(`workspaces/${time_entry.workspace_id}/time_entries`, {
       created_with: 'saintedlama/toggl-client',
       ...time_entry,
@@ -55,12 +49,6 @@ class TimeEntries {
    * @memberof TimeEntries
    */
   async start(time_entry) {
-    if (!time_entry || !Object.prototype.hasOwnProperty.call(time_entry, 'workspace_id')) {
-      throw new Error('The parameters must include workspace_id');
-    }
-    if (!time_entry || !Object.prototype.hasOwnProperty.call(time_entry, 'start')) {
-      throw new Error('The parameters must include start');
-    }
     return await this.client.post(`workspaces/${time_entry.workspace_id}/time_entries`, {
       created_with: 'saintedlama/toggl-client',
       ...time_entry,
@@ -101,9 +89,6 @@ class TimeEntries {
    * @memberof TimeEntries
    */
   async update(id, time_entry) {
-    if (!time_entry || !Object.prototype.hasOwnProperty.call(time_entry, 'workspace_id')) {
-      throw new Error('The parameters must include workspace_id');
-    }
     return await this.client.put(`workspaces/${time_entry.workspace_id}/time_entries/${id}`, time_entry);
   }
 

--- a/lib/time-entries.js
+++ b/lib/time-entries.js
@@ -35,6 +35,12 @@ class TimeEntries {
    * @memberof TimeEntries
    */
   async create(time_entry) {
+    if (!time_entry || !Object.prototype.hasOwnProperty.call(time_entry, 'workspace_id')) {
+      throw new Error('The parameters must include workspace_id');
+    }
+    if (!time_entry || !Object.prototype.hasOwnProperty.call(time_entry, 'start')) {
+      throw new Error('The parameters must include start');
+    }
     return await this.client.post(`workspaces/${time_entry.workspace_id}/time_entries`, {
       created_with: 'saintedlama/toggl-client',
       ...time_entry,
@@ -49,6 +55,12 @@ class TimeEntries {
    * @memberof TimeEntries
    */
   async start(time_entry) {
+    if (!time_entry || !Object.prototype.hasOwnProperty.call(time_entry, 'workspace_id')) {
+      throw new Error('The parameters must include workspace_id');
+    }
+    if (!time_entry || !Object.prototype.hasOwnProperty.call(time_entry, 'start')) {
+      throw new Error('The parameters must include start');
+    }
     return await this.client.post(`workspaces/${time_entry.workspace_id}/time_entries`, {
       created_with: 'saintedlama/toggl-client',
       ...time_entry,
@@ -89,6 +101,9 @@ class TimeEntries {
    * @memberof TimeEntries
    */
   async update(id, time_entry) {
+    if (!time_entry || !Object.prototype.hasOwnProperty.call(time_entry, 'workspace_id')) {
+      throw new Error('The parameters must include workspace_id');
+    }
     return await this.client.put(`workspaces/${time_entry.workspace_id}/time_entries/${id}`, time_entry);
   }
 

--- a/lib/time-entries.js
+++ b/lib/time-entries.js
@@ -1,4 +1,5 @@
 import { mapData } from './utils.js';
+import dayjs from 'dayjs';
 
 /**
  * Access time entries. See https://github.com/toggl/toggl_api_docs/blob/master/chapters/time_entries.md
@@ -11,7 +12,9 @@ class TimeEntries {
   }
 
   /**
-   * Lists time entries
+   * Lists time entries. The `query` must include `start_date` and `end_date`. Note that due to
+   * limitations of the v9 API, start_date must not be earlier than 2023-01-01. If you want results
+   * further back, use the reports endpoints.
    *
    * @param {*} query
    * @returns List of time entries
@@ -68,10 +71,10 @@ class TimeEntries {
   }
 
   /**
- * Stops the current running time entry
- * @returns
- * @memberof TimeEntries
- */
+   * Stops the current running time entry
+   * @returns
+   * @memberof TimeEntries
+   */
   async stop(time_entry) {
     const workspace_id = time_entry.workspace_id;
     const time_entry_id = time_entry.id;
@@ -79,16 +82,19 @@ class TimeEntries {
   }
 
   /**
-   * Gets the time entry specified by idt
+   * Gets the time entry specified by id. Due to limitations of the v9 API, start_date must not be
+   * earlier than 2023-01-01. If you want results further back, use the reports endpoints.
    *
    * @param {*} id
    * @returns TimeEntry
    */
   async get(id) {
-    // FIXME make these dates dynamic
-    const timeEntries = await this.client.get('me/time_entries', { start_date: '2023-01-01', end_date: '2023-04-02' });
+    const timeEntries = await this.client.get('me/time_entries', {
+      start_date: '2021-01-01',
+      end_date: dayjs().add(1, 'day').format('YYYY-MM-DD'),
+    });
     const timeEntry = timeEntries.filter((x) => x.id == id)[0];
-    return timeEntry
+    return timeEntry;
   }
 
   /**

--- a/lib/time-entries.js
+++ b/lib/time-entries.js
@@ -13,7 +13,7 @@ class TimeEntries {
 
   /**
    * Lists time entries. The `query` must include `start_date` and `end_date`. Note that due to
-   * limitations of the v9 API, start_date must not be earlier than 2023-01-01. If you want results
+   * limitations of the v9 API, start_date must not be earlier 3 months ago. If you want results
    * further back, use the reports endpoints.
    *
    * @param {*} query
@@ -83,14 +83,14 @@ class TimeEntries {
 
   /**
    * Gets the time entry specified by id. Due to limitations of the v9 API, start_date must not be
-   * earlier than 2023-01-01. If you want results further back, use the reports endpoints.
+   * earlier than 3 months ago. If you want results further back, use the reports endpoints.
    *
    * @param {*} id
    * @returns TimeEntry
    */
   async get(id) {
     const timeEntries = await this.client.get('me/time_entries', {
-      start_date: '2021-01-01',
+      start_date: dayjs().subtract(3, 'month').format('YYYY-MM-DD'),
       end_date: dayjs().add(1, 'day').format('YYYY-MM-DD'),
     });
     const timeEntry = timeEntries.filter((x) => x.id == id)[0];

--- a/lib/time-entries.js
+++ b/lib/time-entries.js
@@ -1,4 +1,3 @@
-import { mapData } from './utils.js';
 import dayjs from 'dayjs';
 
 /**

--- a/lib/time-entries.js
+++ b/lib/time-entries.js
@@ -36,14 +36,14 @@ class TimeEntries {
    */
   async create(time_entry) {
     return await this.client.post(`workspaces/${time_entry.workspace_id}/time_entries`, {
-      created_with: 'node-toggle-client',
+      created_with: 'saintedlama/toggl-client',
       ...time_entry,
     });
   }
 
   async start(time_entry) {
     return await this.client.post(`workspaces/${time_entry.workspace_id}/time_entries`, {
-      created_with: 'node-toggle-client',
+      created_with: 'saintedlama/toggl-client',
       ...time_entry,
     });
   }

--- a/lib/time-entries.js
+++ b/lib/time-entries.js
@@ -15,7 +15,7 @@ class TimeEntries {
    * limitations of the v9 API, start_date must not be earlier 3 months ago. If you want results
    * further back, use the reports endpoints.
    *
-   * @param {*} query
+   * @param {*} query must include `start_date` and `end_date` and must be within the last 30 days.
    * @returns List of time entries
    * @memberof TimeEntries
    */
@@ -32,7 +32,7 @@ class TimeEntries {
   /**
    * Creates a new time entry
    *
-   * @param {*} time_entry
+   * @param {*} time_entry must include `workspace_id` and `start`
    * @returns
    * @memberof TimeEntries
    */
@@ -52,7 +52,7 @@ class TimeEntries {
   /**
    * Creates a new time entry
    *
-   * @param {*} time_entry
+   * @param {*} time_entry must include `workspace_id` and `start`
    * @returns
    * @memberof TimeEntries
    */

--- a/lib/time-entries.js
+++ b/lib/time-entries.js
@@ -35,19 +35,43 @@ class TimeEntries {
    * @memberof TimeEntries
    */
   async create(time_entry) {
+    if (!time_entry || !Object.prototype.hasOwnProperty.call(time_entry, 'workspace_id')) {
+      throw new Error('The parameters must include workspace_id');
+    }
+    if (!time_entry || !Object.prototype.hasOwnProperty.call(time_entry, 'start')) {
+      throw new Error('The parameters must include start');
+    }
     return await this.client.post(`workspaces/${time_entry.workspace_id}/time_entries`, {
       created_with: 'saintedlama/toggl-client',
       ...time_entry,
     });
   }
 
+  /**
+   * Creates a new time entry
+   *
+   * @param {*} time_entry
+   * @returns
+   * @memberof TimeEntries
+   */
   async start(time_entry) {
+    if (!time_entry || !Object.prototype.hasOwnProperty.call(time_entry, 'workspace_id')) {
+      throw new Error('The parameters must include workspace_id');
+    }
+    if (!time_entry || !Object.prototype.hasOwnProperty.call(time_entry, 'start')) {
+      throw new Error('The parameters must include start');
+    }
     return await this.client.post(`workspaces/${time_entry.workspace_id}/time_entries`, {
       created_with: 'saintedlama/toggl-client',
       ...time_entry,
     });
   }
 
+    /**
+   * Stops the current running time entry
+   * @returns
+   * @memberof TimeEntries
+   */
   async stop(time_entry) {
     const workspace_id = time_entry.workspace_id;
     const time_entry_id = time_entry.id;
@@ -59,14 +83,35 @@ class TimeEntries {
     return mapData(await this.client.get(`time_entries/${id}`));
   }
 
+  /**
+   * Gets the current running time entry
+   * @returns
+   * @memberof TimeEntries
+   */
   async current() {
     return await this.client.get(`me/time_entries/current`);
   }
 
+  /**
+   * Updates an existing time entry
+   *
+   * @param {number} id
+   * @param {*} time_entry
+   * @returns
+   * @memberof TimeEntries
+   */
   async update(id, time_entry) {
+    if (!time_entry || !Object.prototype.hasOwnProperty.call(time_entry, 'workspace_id')) {
+      throw new Error('The parameters must include workspace_id');
+    }
     return await this.client.put(`workspaces/${time_entry.workspace_id}/time_entries/${id}`, time_entry);
   }
 
+  /**
+   * Delete an existing time entry
+   *
+   * @param {number} id
+   */
   async delete(id) {
     await this.client.delete(`time_entries/${id}`);
   }

--- a/test/smoke-test.js
+++ b/test/smoke-test.js
@@ -6,15 +6,19 @@ import togglClient from '../index.js';
 const debug = debugClient('toggl-client-tests');
 
 describe('smoke test', () => {
-  before(() => {
+  let client, workspace_id;
+  before(async () => {
     if (!process.env.TOGGL_API_TOKEN) {
       console.error('Please make sure to set the environment variable "TOGGL_API_TOKEN" before running the smoke tests');
       process.exit(1);
     }
+
+    client = togglClient();
+    const workspaces = await client.workspaces.list();
+    workspace_id = workspaces[0].id;
   });
 
   it('should list workspaces', async () => {
-    const client = togglClient();
     const workspaces = await client.workspaces.list();
 
     debug(workspaces);
@@ -22,7 +26,6 @@ describe('smoke test', () => {
   });
 
   it('should list projects in a workspace', async () => {
-    const client = togglClient();
     const workspaces = await client.workspaces.list();
 
     for (const workspace of workspaces) {
@@ -34,11 +37,9 @@ describe('smoke test', () => {
   });
 
   it('should get a details report', async () => {
-    const client = togglClient();
 
     // FIXME: Add a time entry before to build a fixture
-    const workspaces = await client.workspaces.list();
-    const detailsReport = await client.reports.details(workspaces[0].id, {
+    const detailsReport = await client.reports.details(workspace_id, {
       start_date: dayjs().subtract(1, 'week').format('YYYY-MM-DD'),
     });
 
@@ -56,12 +57,9 @@ describe('smoke test', () => {
   });
 
   it('should throw an error if a start date is not provided with a details report', async () => {
-    const client = togglClient();
-
-    const workspaces = await client.workspaces.list();
 
     try {
-      await client.reports.details(workspaces[0].id);
+      await client.reports.details(workspace_id);
       expect.fail('Expected an error to be thrown');
     } catch (e) {
       expect(e.message).to.equal('The parameters must include start_date');
@@ -69,10 +67,8 @@ describe('smoke test', () => {
   });
 
   it('should get a weekly report', async () => {
-    const client = togglClient();
 
-    const workspaces = await client.workspaces.list();
-    const weeklyReport = await client.reports.weekly(workspaces[0].id);
+    const weeklyReport = await client.reports.weekly(workspace_id);
     debug(weeklyReport);
     expect(weeklyReport).to.exist.to.be.an('array');
     expect(weeklyReport).to.have.property('page');
@@ -83,10 +79,8 @@ describe('smoke test', () => {
   });
 
   it('should get a summary report', async () => {
-    const client = togglClient();
 
-    const workspaces = await client.workspaces.list();
-    const summaryReport = await client.reports.summary(workspaces[0].id, {
+    const summaryReport = await client.reports.summary(workspace_id, {
       start_date: dayjs().subtract(1, 'week').format('YYYY-MM-DD'),
     });
     debug(summaryReport);
@@ -96,12 +90,9 @@ describe('smoke test', () => {
   });
 
   it('should throw an error if a start date is not provided with a summary report', async () => {
-    const client = togglClient();
-
-    const workspaces = await client.workspaces.list();
 
     try {
-      await client.reports.summary(workspaces[0].id);
+      await client.reports.summary(workspace_id);
       expect.fail('Expected an error to be thrown');
     } catch (e) {
       expect(e.message).to.equal('The parameters must include start_date');
@@ -109,7 +100,6 @@ describe('smoke test', () => {
   });
 
   it('should get a user', async () => {
-    const client = togglClient();
     const user = await client.user.current();
 
     debug(user);
@@ -123,14 +113,12 @@ describe('smoke test', () => {
   });
 
   it.skip('should get a new API token', async () => {
-    const client = togglClient();
     const newToken = await client.user.resetToken();
     debug(newToken);
     expect(newToken).to.exist.to.be.an('string');
   });
 
   it('should throw an error if current password not supplied', async () => {
-    const client = togglClient();
     const user = {
       password: 'foo',
     };
@@ -138,7 +126,6 @@ describe('smoke test', () => {
   });
 
   it('should throw an error if time of day format is invalid', async () => {
-    const client = togglClient();
     const user = {
       timeofday_format: 'foo',
     };
@@ -146,7 +133,6 @@ describe('smoke test', () => {
   });
 
   it('should throw an error if date format is invalid', async () => {
-    const client = togglClient();
     const user = {
       dateFormat: 'foo',
     };
@@ -158,12 +144,10 @@ describe('smoke test', () => {
   });
 
   it.skip('should generate time entries', async () => {
-    const client = togglClient();
-    const workspaces = await client.workspaces.list();
 
     for (let i = 0; i < 52; i++) {
       const timeEntryCreated = await client.timeEntries.create({
-        wid: workspaces[0].id,
+        wid: workspace_id,
         duration: 1200, // 20min
         start: new Date().toISOString(),
         description: 'Test Entry',
@@ -176,9 +160,7 @@ describe('smoke test', () => {
   });
 
   it('should list a users tags', async () => {
-    const client = togglClient();
-    const workspaces = await client.workspaces.list();
-    const tags = await client.workspaces.tags(workspaces[0].id);
+    const tags = await client.workspaces.tags(workspace_id);
     debug(tags);
     expect(tags).to.exist.to.be.an('array');
     expect(tags[0].name).to.exist;

--- a/test/smoke-test.js
+++ b/test/smoke-test.js
@@ -37,7 +37,6 @@ describe('smoke test', () => {
   });
 
   it('should get a details report', async () => {
-
     // FIXME: Add a time entry before to build a fixture
     const detailsReport = await client.reports.details(workspace_id, {
       start_date: dayjs().subtract(1, 'week').format('YYYY-MM-DD'),
@@ -57,7 +56,6 @@ describe('smoke test', () => {
   });
 
   it('should throw an error if a start date is not provided with a details report', async () => {
-
     try {
       await client.reports.details(workspace_id);
       expect.fail('Expected an error to be thrown');
@@ -67,7 +65,6 @@ describe('smoke test', () => {
   });
 
   it('should get a weekly report', async () => {
-
     const weeklyReport = await client.reports.weekly(workspace_id);
     debug(weeklyReport);
     expect(weeklyReport).to.exist.to.be.an('array');
@@ -79,7 +76,6 @@ describe('smoke test', () => {
   });
 
   it('should get a summary report', async () => {
-
     const summaryReport = await client.reports.summary(workspace_id, {
       start_date: dayjs().subtract(1, 'week').format('YYYY-MM-DD'),
     });
@@ -90,7 +86,6 @@ describe('smoke test', () => {
   });
 
   it('should throw an error if a start date is not provided with a summary report', async () => {
-
     try {
       await client.reports.summary(workspace_id);
       expect.fail('Expected an error to be thrown');
@@ -144,7 +139,6 @@ describe('smoke test', () => {
   });
 
   it.skip('should generate time entries', async () => {
-
     for (let i = 0; i < 52; i++) {
       const timeEntryCreated = await client.timeEntries.create({
         wid: workspace_id,

--- a/test/time-entries.test.js
+++ b/test/time-entries.test.js
@@ -6,10 +6,16 @@ import togglClient from '../index.js';
 const debug = debugClient('toggl-client-tests-time-entries');
 
 describe('time-entries', async () => {
-  it.skip('should get a time entry by id', async () => {
+  it.only('should get a time entry by id', async () => {
     const client = togglClient();
-    const timeEntry = await client.timeEntries.get(42);
+    // FIXME make this portable
+    const timeEntryId = 2901042224;
+    const timeEntry = await client.timeEntries.get(timeEntryId);
     debug(timeEntry);
+    expect(timeEntry).to.be.an('object');
+    expect(timeEntry).to.have.property('workspace_id');
+    expect(timeEntry).to.have.property('project_id');
+    expect(timeEntry).to.have.property('id').equal(timeEntryId);
   });
 
   it('should get the current running time entry', async () => {

--- a/test/time-entries.test.js
+++ b/test/time-entries.test.js
@@ -8,8 +8,16 @@ const debug = debugClient('toggl-client-tests-time-entries');
 describe('time-entries', async () => {
   it('should get a time entry by id', async () => {
     const client = togglClient();
-    // FIXME make this portable
-    const timeEntryId = 2901042224;
+    const query = {
+      start_date: dayjs().subtract(3, 'month').format('YYYY-MM-DD'),
+      end_date: dayjs().add(1, 'day').format('YYYY-MM-DD'),
+    };
+    const timeEntries = await client.timeEntries.list(query);
+    debug(timeEntries);
+    expect(timeEntries).to.be.an('array');
+    const index = Math.floor(timeEntries.length / 2); // get the middle entry
+    debug(index);
+    const timeEntryId = timeEntries[index].id;
     const timeEntry = await client.timeEntries.get(timeEntryId);
     debug(timeEntry);
     expect(timeEntry).to.be.an('object');
@@ -32,8 +40,8 @@ describe('time-entries', async () => {
   it('should list time entries', async () => {
     const client = togglClient();
     const query = {
-      start_date: '2023-02-04',
-      end_date: '2023-02-08',
+      start_date: dayjs().subtract(3, 'month').format('YYYY-MM-DD'),
+      end_date: dayjs().add(1, 'day').format('YYYY-MM-DD'),
     };
     const timeEntries = await client.timeEntries.list(query);
     debug(timeEntries);
@@ -51,7 +59,6 @@ describe('time-entries', async () => {
   it('should error if parameters are not included with list', async () => {
     const client = togglClient();
     try {
-      // FIXME try out the ChatGPT solution
       await client.timeEntries.list();
       expect.fail('Expected an error to be thrown');
     } catch (e) {

--- a/test/time-entries.test.js
+++ b/test/time-entries.test.js
@@ -22,9 +22,11 @@ describe('time-entries', async () => {
     const client = togglClient();
     const timeEntry = await client.timeEntries.current();
     debug(timeEntry);
-    expect(timeEntry).to.be.an('object'); // FIXME this fails if there is no running time entry
-    expect(timeEntry).to.have.property('workspace_id');
-    expect(timeEntry).to.have.property('project_id');
+    expect(timeEntry).to.be.oneOf([null, Object]); // FIXME this fails if there is a running time entry
+    if (timeEntry) {
+      expect(timeEntry).to.have.property('workspace_id');
+      expect(timeEntry).to.have.property('project_id');
+    }
   });
 
   it('should list time entries', async () => {

--- a/test/time-entries.test.js
+++ b/test/time-entries.test.js
@@ -6,7 +6,7 @@ import togglClient from '../index.js';
 const debug = debugClient('toggl-client-tests-time-entries');
 
 describe('time-entries', async () => {
-  it.only('should get a time entry by id', async () => {
+  it('should get a time entry by id', async () => {
     const client = togglClient();
     // FIXME make this portable
     const timeEntryId = 2901042224;
@@ -18,7 +18,7 @@ describe('time-entries', async () => {
     expect(timeEntry).to.have.property('id').equal(timeEntryId);
   });
 
-  it('should get the current running time entry', async () => {
+  it.only('should get the current running time entry', async () => {
     const client = togglClient();
     const timeEntry = await client.timeEntries.current();
     debug(timeEntry);

--- a/test/time-entries.test.js
+++ b/test/time-entries.test.js
@@ -18,11 +18,11 @@ describe('time-entries', async () => {
     expect(timeEntry).to.have.property('id').equal(timeEntryId);
   });
 
-  it.only('should get the current running time entry', async () => {
+  it('should get the current running time entry', async () => {
     const client = togglClient();
     const timeEntry = await client.timeEntries.current();
     debug(timeEntry);
-    expect(timeEntry).to.be.oneOf([null, Object]); // FIXME this fails if there is a running time entry
+    expect(typeof timeEntry).to.be.oneOf([null, 'object']);
     if (timeEntry) {
       expect(timeEntry).to.have.property('workspace_id');
       expect(timeEntry).to.have.property('project_id');
@@ -51,6 +51,7 @@ describe('time-entries', async () => {
   it('should error if parameters are not included with list', async () => {
     const client = togglClient();
     try {
+      // FIXME try out the ChatGPT solution
       await client.timeEntries.list();
       expect.fail('Expected an error to be thrown');
     } catch (e) {

--- a/test/time-entries.test.js
+++ b/test/time-entries.test.js
@@ -1,0 +1,92 @@
+import { expect } from 'chai';
+import debugClient from 'debug';
+import togglClient from '../index.js';
+
+const debug = debugClient('toggl-client-tests-time-entries');
+
+describe.only('time-entries', async () => {
+  it.skip('should get a time entry by id', async () => {
+    const client = togglClient();
+    const timeEntry = await client.timeEntries.get(42);
+    debug(timeEntry);
+  });
+
+  it('should get the current running time entry', async () => {
+    const client = togglClient();
+    const timeEntry = await client.timeEntries.current();
+    debug(timeEntry);
+    expect(timeEntry).to.be.an('object'); // FIXME this fails if there is no running time entry
+    expect(timeEntry).to.have.property('workspace_id');
+    expect(timeEntry).to.have.property('project_id');
+  });
+
+  it('should list time entries', async () => {
+    const client = togglClient();
+    const query = {
+      start_date: '2023-02-04',
+      end_date: '2023-02-08',
+    }
+    const timeEntries = await client.timeEntries.list(query);
+    debug(timeEntries);
+    expect(timeEntries).to.be.an('array')
+    const index = Math.floor(timeEntries.length / 2); // get the middle entry
+    debug(index)
+    const timeEntry = timeEntries[index];
+    debug(timeEntry);
+
+    expect(timeEntry).to.be.an('object');
+    expect(timeEntry).to.have.property('workspace_id');
+    expect(timeEntry).to.have.property('project_id');
+  });
+
+  it('should error if parameters are not included with list', async () => {
+    const client = togglClient();
+    try {
+      await client.timeEntries.list();
+      expect.fail('Expected an error to be thrown');
+    } catch (e) {
+      expect(e.message).to.equal('The parameters must include start_date');
+    }
+
+    try {
+      await client.timeEntries.list({ start_date: '2023-02-04' });
+      expect.fail('Expected an error to be thrown');
+    } catch (e) {
+      expect(e.message).to.equal('The parameters must include end_date');
+    }
+  });
+
+  it.skip('should create, update and delete a time-entry', async () => {
+    const tag = { name: `testing-${Date.now()}` };
+    debug(tag);
+
+    const client = togglClient();
+    const workspaces = await client.workspaces.list();
+    const workspace_id = workspaces[0].id;
+    debug(workspace_id);
+
+    const createdTag = await client.tags.create(workspace_id, tag);
+    debug('createdTag');
+    debug(createdTag);
+    expect(createdTag).to.be.an('object');
+    expect(createdTag).to.have.property('name').equal(tag.name);
+    expect(createdTag).to.have.property('at');
+    expect(createdTag).to.have.property('workspace_id');
+    expect(createdTag).to.have.property('id');
+
+    const updatedTagName = `${tag.name}-updated`;
+
+    const updatedTag = await client.tags.update(workspace_id, createdTag.id, { name: updatedTagName });
+    debug('updatedTag');
+    debug(updatedTag);
+    expect(updatedTag).to.be.an('object');
+    expect(updatedTag).to.have.property('name').equal(updatedTagName);
+    expect(updatedTag).to.have.property('at');
+    expect(updatedTag).to.have.property('workspace_id');
+    expect(updatedTag).to.have.property('id');
+
+    await client.tags.delete(workspace_id, updatedTag.id);
+    const tags = await client.workspaces.tags(workspace_id);
+    expect(tags).to.not.include.members([updatedTag]);
+  });
+});


### PR DESCRIPTION
Updates the `time-entries` module; all functions support v9 API and added a new test suite specificaly for `time-entries

- updates created_with to `saintedlama/toggl-clienti`
- updates `get(id)` to work in v9, limiting the records you can get to the last 3 months 
- Adds time-entries test suite
- Adds time-entries doc blocks
- Adds required parameter checks to TimeEntry methods, `list` requires `start_date` and `end_date` _and they are limted to last 3 months_ 
- Updates the smoketest repeated calls to before function to avoid hitting the toggl API ratelimits.

Fixes #33
