### PR TITLE
feat: updates user module for remaining v9 API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ Returns **any**
 
 ### User
 
-Access users. See <https://github.com/toggl/toggl_api_docs/blob/master/chapters/users.md>
+Access users. See https://developers.track.toggl.com/docs/api/me
 
 #### current
 
@@ -370,15 +370,26 @@ Gets the current user
 
 ##### Parameters
 
-*   `query` **any** 
+None
 
-Returns **any** The current user. By default the request responds with user properties. From the API documentation, to get all the workspaces, clients, projects, tasks,
-time entries and tags which the user can see, add the parameter with_related_data=true If you want to retrieve objects which have changed after
-certain time, add since parameter to the query. The value should be a unix timestamp (e.g. since=1362579886)
+
+Returns **any** The current user. 
+
+#### update
+
+Updates the user. You can only update `country_id`, `current_password`, `default_workspace_id`, `email`, `fullname`,`name`, `password`, `timezone`. See https://developers.track.toggl.com/docs/api/me#put-me
+
+##### Parameters
+
+*   `user` **any** The updated user object.
+
+
+
+Returns **any** The updated user. 
 
 #### resetToken
 
-Resets API token <https://github.com/toggl/toggl_api_docs/blob/master/chapters/users.md#reset-api-token>
+Resets API token https://developers.track.toggl.com/docs/api/authentication#post-resettoken
 
 Returns **any** New API token {String}
 

--- a/lib/user.js
+++ b/lib/user.js
@@ -48,12 +48,12 @@ class User {
   }
 
   /**
-   * Resets API token https://github.com/toggl/toggl_api_docs/blob/master/chapters/users.md#reset-api-token
+   * Resets API token https://developers.track.toggl.com/docs/api/authentication#post-resettoken
    * @returns New API token {String}
    * @memberof User
    */
   async resetToken() {
-    return await this.client.post('reset_token');
+    return await this.client.post('me/reset_token');
   }
 }
 

--- a/lib/user.js
+++ b/lib/user.js
@@ -1,5 +1,5 @@
 /**
- * Access users. See https://github.com/toggl/toggl_api_docs/blob/master/chapters/users.md
+ * Access users. See https://developers.track.toggl.com/docs/api/me
  *
  * @class User
  */
@@ -24,7 +24,7 @@ class User {
 
   // /**
   //  *
-  //  * @param {*} user See https://github.com/toggl/toggl_api_docs/blob/master/chapters/users.md#update-user-data
+  //  * @param {*} user See https://developers.track.toggl.com/docs/api/me#put-me
   //  * @returns The updated user.
   //  * @memberof User
   //  */

--- a/lib/user.js
+++ b/lib/user.js
@@ -22,28 +22,21 @@ class User {
     return await this.client.get(this.endpoint);
   }
 
-  // /**
-  //  *
-  //  * @param {*} user See https://developers.track.toggl.com/docs/api/me#put-me
-  //  * @returns The updated user.
-  //  * @memberof User
-  //  */
+  /**
+   * Updates the user. You can only update `country_id`, `current_password`, `default_workspace_id`, `email`, `fullname`,`name`, `password`, `timezone`
+   *
+   * See https://developers.track.toggl.com/docs/api/me#put-me
+   *
+   * @param {*} user
+   * @returns The updated user.
+   * @memberof User
+   */
   async update(user) {
     // Check if attempting to change the password
     if (user.password && !user.current_password) {
       throw new Error('To change the password you must include the current password');
     }
 
-    // check if the time of day format is valid
-    const validTimeOfDayFormat = ['H:mm', 'h:mm A'];
-    if (user.timeofday_format && !validTimeOfDayFormat.find(user.timeofday_format)) {
-      throw new Error('timeofday_format must be one of H:mm or h:mm');
-    }
-
-    const validDateFormat = ['YYYY-MM-DD', 'DD.MM.YYYY', 'DD-MM-YYYY', 'MM/DD/YYYY', 'DD/MM/YYYY', 'MM-DD-YYYY'];
-    if (user.dateFormat && !validDateFormat.find(user.date_format)) {
-      throw new Error('date_format must be one of "YYYY-MM-DD", "DD.MM.YYYY", "DD-MM-YYYY", "MM/DD/YYYY", "DD/MM/YYYY", "MM-DD-YYYY"');
-    }
     return await this.client.put(this.endpoint, user);
   }
 

--- a/lib/user.js
+++ b/lib/user.js
@@ -44,7 +44,7 @@ class User {
     if (user.dateFormat && !validDateFormat.find(user.date_format)) {
       throw new Error('date_format must be one of "YYYY-MM-DD", "DD.MM.YYYY", "DD-MM-YYYY", "MM/DD/YYYY", "DD/MM/YYYY", "MM-DD-YYYY"');
     }
-    return await this.client.put(this.endpoint, { user: user });
+    return await this.client.put(this.endpoint, user);
   }
 
   /**

--- a/lib/user.js
+++ b/lib/user.js
@@ -12,14 +12,14 @@ class User {
   /**
    * Gets the current user
    *
-   * @param {*} query
-   * @returns The current user. By default the request responds with user properties. From the API documentation, to get all the workspaces, clients, projects, tasks,
-   * time entries and tags which the user can see, add the parameter with_related_data=true If you want to retrieve objects which have changed after
-   * certain time, add since parameter to the query. The value should be a unix timestamp (e.g. since=1362579886)
+   * @returns The current user.
+   *
+   * See https://developers.track.toggl.com/docs/api/me#get-me
+   *
    * @memberof User
    */
-  async current(query) {
-    return await this.client.get(this.endpoint, query);
+  async current() {
+    return await this.client.get(this.endpoint);
   }
 
   // /**

--- a/test/smoke-test.js
+++ b/test/smoke-test.js
@@ -108,27 +108,6 @@ describe('smoke test', () => {
     }
   });
 
-  it('should get a user', async () => {
-    const client = togglClient();
-    const user = await client.user.current();
-
-    debug(user);
-
-    expect(user).to.exist.to.be.an('object');
-    expect(user.email).to.exist;
-    expect(user).to.have.property('email');
-    expect(user).to.have.property('fullname');
-    expect(user).to.have.property('api_token');
-    expect(user).to.have.property('default_workspace_id');
-  });
-
-  it.skip('should get a new API token', async () => {
-    const client = togglClient();
-    const newToken = await client.user.resetToken();
-    debug(newToken);
-    expect(newToken).to.exist.to.be.an('string');
-  });
-
   it('should throw an error if current password not supplied', async () => {
     const client = togglClient();
     const user = {

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1,12 +1,11 @@
 import { expect } from 'chai';
-import dayjs from 'dayjs';
 import debugClient from 'debug';
 import togglClient from '../index.js';
 
 const debug = debugClient('toggl-client-tests-user');
 
-describe.only('user', () => {
-  let client, workspace_id;
+describe('user', () => {
+  let client;
   before(async () => {
     if (!process.env.TOGGL_API_TOKEN) {
       console.error('Please make sure to set the environment variable "TOGGL_API_TOKEN" before running the smoke tests');
@@ -14,8 +13,6 @@ describe.only('user', () => {
     }
 
     client = togglClient();
-    const workspaces = await client.workspaces.list();
-    workspace_id = workspaces[0].id;
   });
 
   it('should get a user', async () => {
@@ -31,30 +28,29 @@ describe.only('user', () => {
     expect(user).to.have.property('default_workspace_id');
   });
 
-  it('should update a user', async() => {
+  it('should update a user', async () => {
     // get current user
     const user = await client.user.current();
     debug(user);
-    const updatedFullname = user.fullname + ' updated'
+    const updatedFullname = user.fullname + ' updated';
 
     // update the fullname name
-    let updatedUser = await client.user.update({fullname: updatedFullname})
-    debug(updatedUser)
+    let updatedUser = await client.user.update({ fullname: updatedFullname });
+    debug(updatedUser);
     expect(updatedUser).to.exist.to.be.an('object');
     expect(updatedUser).to.have.property('fullname').equal(updatedFullname);
 
-
     // put the fullname back
-    updatedUser = await client.user.update({fullname: user.fullname})
-    debug(updatedUser)
+    updatedUser = await client.user.update({ fullname: user.fullname });
+    debug(updatedUser);
     expect(updatedUser).to.exist.to.be.an('object');
     expect(updatedUser).to.have.property('fullname');
     expect(updatedUser).to.have.property('fullname').equal(user.fullname);
-  })
+  });
 
   it.skip('should get a new API token', async () => {
     const newToken = await client.user.resetToken();
     debug(newToken);
     expect(newToken).to.exist.to.be.an('string');
   });
-})
+});

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -31,6 +31,27 @@ describe.only('user', () => {
     expect(user).to.have.property('default_workspace_id');
   });
 
+  it('should update a user', async() => {
+    // get current user
+    const user = await client.user.current();
+    debug(user);
+    const updatedFullname = user.fullname + ' updated'
+
+    // update the fullname name
+    let updatedUser = await client.user.update({fullname: updatedFullname})
+    debug(updatedUser)
+    expect(updatedUser).to.exist.to.be.an('object');
+    expect(updatedUser).to.have.property('fullname').equal(updatedFullname);
+
+
+    // put the fullname back
+    updatedUser = await client.user.update({fullname: user.fullname})
+    debug(updatedUser)
+    expect(updatedUser).to.exist.to.be.an('object');
+    expect(updatedUser).to.have.property('fullname');
+    expect(updatedUser).to.have.property('fullname').equal(user.fullname);
+  })
+
   it.skip('should get a new API token', async () => {
     const newToken = await client.user.resetToken();
     debug(newToken);

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import dayjs from 'dayjs';
+import debugClient from 'debug';
+import togglClient from '../index.js';
+
+const debug = debugClient('toggl-client-tests-user');
+
+describe.only('user', () => {
+  let client, workspace_id;
+  before(async () => {
+    if (!process.env.TOGGL_API_TOKEN) {
+      console.error('Please make sure to set the environment variable "TOGGL_API_TOKEN" before running the smoke tests');
+      process.exit(1);
+    }
+
+    client = togglClient();
+    const workspaces = await client.workspaces.list();
+    workspace_id = workspaces[0].id;
+  });
+
+  it('should get a user', async () => {
+    const user = await client.user.current();
+
+    debug(user);
+
+    expect(user).to.exist.to.be.an('object');
+    expect(user.email).to.exist;
+    expect(user).to.have.property('email');
+    expect(user).to.have.property('fullname');
+    expect(user).to.have.property('api_token');
+    expect(user).to.have.property('default_workspace_id');
+  });
+
+  it.skip('should get a new API token', async () => {
+    const newToken = await client.user.resetToken();
+    debug(newToken);
+    expect(newToken).to.exist.to.be.an('string');
+  });
+})


### PR DESCRIPTION
Updates User module endpoints to support v9 API

- Updates reset API token for new endpoint
- Updates current user() - it does not take any query params
- Removes validation in `update()` for non-applicable user params
- Updates doc blocks
- moves user tests to new user.test.js and adds test for updating the user

Fixes #36
