### PR TITLE
ci: update node version for workflows and some test fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           registry-url: 'https://registry.npmjs.org'
       - name: npm install
         run: npm ci

--- a/test/project-users.test.js
+++ b/test/project-users.test.js
@@ -4,7 +4,7 @@ import togglClient from '../index.js';
 
 const debug = debugClient('toggl-client-tests-project-users');
 
-describe('projects', () => {
+describe('projects-users', () => {
   let client;
   let workspace_id;
   before(async () => {

--- a/test/projects.test.js
+++ b/test/projects.test.js
@@ -55,7 +55,7 @@ describe('projects', () => {
     const project = {
       name: `test-project-${Date.now()}`,
       workspace_id,
-      start_date: new Date().toISOString(),
+      start_date: new Date().toISOString().split('T')[0],
     };
     debug(project);
 


### PR DESCRIPTION
- removes Node 16 and adds Node 20
- fixes a date format in the create/update/delete project tests. It should have been formatted `YYYY-MM-DD` rather than including the time portion
- updates the description in the test suite for the project-users tests

Fixes #66
